### PR TITLE
configs: j721e_evm_hs: Switch to using SR1.1

### DIFF
--- a/configs/j721e_evm_hs_all_defconfig
+++ b/configs/j721e_evm_hs_all_defconfig
@@ -1,5 +1,5 @@
 # J721e EVM configuration for HS devices
-SOC_NAME=j721e_sr2
+SOC_NAME=j721e_sr1_1
 BOARD_NAME=evm
 SECURITY_TYPE=hs
 


### PR DESCRIPTION
Switch to using J721E SR1.1 instead of J721E SR2.0 as currently it is what is supported upstream and is more common.