### PR TITLE
Makefile: Added sdcard-flasher target

### DIFF
--- a/MAKEALL
+++ b/MAKEALL
@@ -16,6 +16,7 @@ build_config() {
 	make -j`nproc` O=$build_path D=$deploy_path mrproper
 	make -j`nproc` O=$build_path D=$deploy_path $config
 	make -j`nproc` O=$build_path D=$deploy_path
+	make -j`nproc` O=$build_path D=$deploy_path sdcard
 }
 
 mkdir -p $BASE_FOLDER
@@ -40,7 +41,7 @@ for config in $DEFCONFIGS
 do
 	LOG=$BASE_FOLDER/$config.txt
 	res=`tail -n 1 $LOG`
-	success=`echo $res|grep 'BUILD COMPLETE:'`
+	success=`echo $res|grep 'SDCARD IMG COMPLETE:'`
 	if [ x"$success" == x ]; then
 		((fail++))
 		echo "===> $config ($LOG) <====" | tee -a "$ERROR_FILE"

--- a/scripts/srf_uenv.txt
+++ b/scripts/srf_uenv.txt
@@ -1,0 +1,7 @@
+# Flash firmware via EFI capsule update
+# Assumes ESP partition is second partition on mmc 1
+#
+setvars=setenv -e -nv -bs -rt OsIndications =0x0000000000000004
+setboot=efidebug boot add -b 1001 cap mmc 1:2 xxx && efidebug boot next 1001
+update=efidebug capsule disk-update
+uenvcmd=run setboot setvars update


### PR DESCRIPTION
sdcard-flasher creates an image with a boot partition with the standard firmware (like with sdcard target) so the board can boot from the sdcard, as well as an ESP partition containing the firmware in capsules.  Upon the next boot (using the boot partition if booting from the sdcard), the firwmware will perform a capsule update to flash this firmware onto the board.

So this image can be used both in the scenario where the on-board flash has never been flashed with the firmware (or it is bricked), as well as when booting from on-board flash and wanting to update that firmware.

Also adds a file that contains the commands to initiate the capsule update process.  This file will be copied into the boot partition of the image as the uEnv.txt file.