### PR TITLE
Makefile: force xz to compress even if target file exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -131,7 +131,7 @@ sdcard: u_boot $(I) $(D)
 # Copy esp partition to image
 	$(Q)dd if=$(I)/esp-partition.raw of=$(D)/sdcard.img bs=1M seek=20 conv=notrunc
 # Save a bit of disk space by compressing the sdcard image
-	$(Q)xz -e $(D)/sdcard.img
+	$(Q)xz -ef $(D)/sdcard.img
 	$(Q)echo "SDCARD IMG COMPLETE: SoC=$(SOC_NAME) Board=$(BOARD_NAME) SECURITY=$(SECURITY_TYPE)"
 
 .PHONY: mrproper


### PR DESCRIPTION
This allows for rebuilding of the image to overwrite a prior build.